### PR TITLE
Make it possible to install local deb packages (FILE protocol)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -48,6 +48,10 @@ for PACKAGE in $(cat $BUILD_DIR/Aptfile); do
     continue
   fi
 
+  if [[ $PACKAGE == file://* ]]; then
+    PACKAGE="file://${BUILD_DIR}/$(echo $PACKAGE | cut -c8-)"
+  fi
+
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
     PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb


### PR DESCRIPTION
Locally available deb files live in directory that is only known at
build time. We build the path to deb files by prepending the value
of variable `BUILD_DIR` to the URLs provided in the Aptfile - only
to those using the FILE protocol.

Closes #5